### PR TITLE
Correct license value in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "https://github.com/cfpb/vax"
   },
-  "license": "CC0-1.0",
+  "license": "SEE LICENSE IN TERMS.md",
   "bugs": "https://github.com/cfpb/vax/issues",
   "dependencies": {
     "commander": "2.9.0",


### PR DESCRIPTION
Just saying `CC0-1.0` is a little too broad, since we're technically in the public domain in the U.S. Per [npm guidance](https://docs.npmjs.com/files/package.json#license), `SEE LICENSE IN <filename>` is the best practice for more complex licensing scenarios like ours.
